### PR TITLE
Add .golangci.yml and .goreleaser.yml

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,6 @@ Fixes # (issue)
 
 ### Quick checks:
 
-- [ ] There is no other [pull request](https://github.com/conduitio/conduit-connector-connectorName/pulls) for the same update/change.
+- [ ] There is no other [pull request](https://github.com/conduitio/conduit-connector-connectorname/pulls) for the same update/change.
 - [ ] I have written unit tests.
 - [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 .vscode
 
 # Binary, built with `make build`
-/conduit-connector-connectorName
+/conduit-connector-connectorname
 
 ### OS ###
 .DS_Store

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,80 @@
+linters-settings:
+  gofmt:
+    simplify: false
+  govet:
+    check-shadowing: false
+  nolintlint:
+    allow-unused: false # report any unused nolint directives
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to mention the specific linter being suppressed
+  gocyclo:
+    min-complexity: 20
+  goconst:
+    ignore-tests: true
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - bodyclose
+    # - depguard
+    - dogsled
+    - durationcheck
+    - errcheck
+    - errname
+    # - errorlint
+    # - exhaustive
+    # - exhaustivestruct
+    - exportloopref
+    # - forbidigo
+    # - forcetypeassert
+    # - funlen
+    # - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    # - cyclop # not interested in package complexities at the moment
+    # - godot
+    - gofmt
+    # - gofumpt
+    - goheader
+    - goimports
+    - revive
+    # - gomnd
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    # - ifshort
+    - ineffassign
+    # - importas
+    # - lll
+    # - misspell
+    - makezero
+    # - nakedret
+    # - nilerr
+    # - nilnil
+    # - nlreturn
+    - noctx
+    - nolintlint
+    # - paralleltest
+    - predeclared
+    # - rowserrcheck
+    - staticcheck
+    - stylecheck
+    # - sqlclosecheck
+    # - tagliatelle
+    # - tenv
+    # - thelper
+    # - tparallel
+    - typecheck
+    - unconvert
+    # - unparam
+    - unused
+    # - wastedassign
+    - whitespace
+    # - wrapcheck
+    # - wsl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+builds:
+  - main: ./cmd/connector/main.go
+    goos:
+      - darwin
+      - linux
+      - windows
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - "-s -w -X 'github.com/conduitio/conduit-connector-connectorName.version={{ .Tag }}'"
+checksum:
+  name_template: checksums.txt
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^go.mod:'
+      - '^.github:'
+      - Merge branch

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - "-s -w -X 'github.com/conduitio/conduit-connector-connectorName.version={{ .Tag }}'"
+      - "-s -w -X 'github.com/conduitio/conduit-connector-connectorname.version={{ .Tag }}'"
 checksum:
   name_template: checksums.txt
 archives:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test test-integration
 
 build:
-	go build -o conduit-connector-connectorName cmd/connector/main.go
+	go build -o conduit-connector-connectorname cmd/connector/main.go
 
 test:
 	go test $(GOTEST_FLAGS) -v -race ./...

--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ This template provides two types of "configs":
 * general configuration (that applies to both, sources and destinations)
 * and source/destination specific configs.
 
-All are defined in `config.go` and are represented by separate types. General configs should be added to `connectorName.Config`,
-whereas any source or destination specific configs should be added to `connectorName.SourceConfig` and 
-`connectorName.DestinationConfig` respectively.
+All are defined in `config.go` and are represented by separate types. General configs should be added to `connectorname.Config`,
+whereas any source or destination specific configs should be added to `connectorname.SourceConfig` and 
+`connectorname.DestinationConfig` respectively.

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	sdk "github.com/conduitio/conduit-connector-sdk"
 
-	connectorName "github.com/conduitio/conduit-connector-connectorName"
+	connectorname "github.com/conduitio/conduit-connector-connectorname"
 )
 
 func main() {
-	sdk.Serve(connectorName.Connector)
+	sdk.Serve(connectorname.Connector)
 }

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-package connectorName
+package connectorname
 
 import "errors"
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,1 +1,1 @@
-package connectorName
+package connectorname

--- a/connector.go
+++ b/connector.go
@@ -1,4 +1,4 @@
-package connectorName
+package connectorname
 
 import sdk "github.com/conduitio/conduit-connector-sdk"
 

--- a/destination.go
+++ b/destination.go
@@ -1,4 +1,4 @@
-package connectorName
+package connectorname
 
 import (
 	"context"

--- a/destination.go
+++ b/destination.go
@@ -2,6 +2,7 @@ package connectorName
 
 import (
 	"context"
+
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/destination_test.go
+++ b/destination_test.go
@@ -1,15 +1,15 @@
-package connectorName_test
+package connectorname_test
 
 import (
 	"context"
 	"strings"
 	"testing"
 
-	connectorName "github.com/conduitio/conduit-connector-connectorName"
+	connectorname "github.com/conduitio/conduit-connector-connectorname"
 )
 
 func TestConfigureDestination_FailsWhenConfigEmpty(t *testing.T) {
-	con := connectorName.Destination{}
+	con := connectorname.Destination{}
 	err := con.Configure(context.Background(), make(map[string]string))
 	if err == nil {
 		t.Error("expected error for missing config params")
@@ -21,7 +21,7 @@ func TestConfigureDestination_FailsWhenConfigEmpty(t *testing.T) {
 }
 
 func TestTeardown_NoOpen(t *testing.T) {
-	con := connectorName.NewDestination()
+	con := connectorname.NewDestination()
 	err := con.Teardown(context.Background())
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)

--- a/destination_test.go
+++ b/destination_test.go
@@ -2,9 +2,10 @@ package connectorName_test
 
 import (
 	"context"
-	connectorName "github.com/conduitio/conduit-connector-connectorName"
 	"strings"
 	"testing"
+
+	connectorName "github.com/conduitio/conduit-connector-connectorName"
 )
 
 func TestConfigureDestination_FailsWhenConfigEmpty(t *testing.T) {
@@ -24,6 +25,5 @@ func TestTeardown_NoOpen(t *testing.T) {
 	err := con.Teardown(context.Background())
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
-
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/conduitio/conduit-connector-connectorName
+module github.com/conduitio/conduit-connector-connectorname
 
 go 1.19
 

--- a/setup.sh
+++ b/setup.sh
@@ -7,19 +7,19 @@ fi
 MODULE_NAME=$1
 if ! [[ "$MODULE_NAME" =~ ^.*\/conduit-connector-(.*)$ ]]
 then
-  echo "Module name '$MODULE_NAME' not in required format 'example/conduit-connector-connectorName'"
+  echo "Module name '$MODULE_NAME' not in required format 'example/conduit-connector-connectorname'"
   exit 1
 fi
 
 CONNECTOR_NAME=${BASH_REMATCH[1]}
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  LC_ALL=C find . -type f ! -name "setup.sh" -exec sed -i "" "s~github.com/conduitio/conduit-connector-connectorName~github.com/$MODULE_NAME~g" {} +
-  LC_ALL=C find . -type f ! -name "setup.sh" -exec sed -i "" "s~connectorName~$CONNECTOR_NAME~g" {} +
+  LC_ALL=C find . -type f ! -name "setup.sh" -exec sed -i "" "s~github.com/conduitio/conduit-connector-connectorname~github.com/$MODULE_NAME~g" {} +
+  LC_ALL=C find . -type f ! -name "setup.sh" -exec sed -i "" "s~connectorname~$CONNECTOR_NAME~g" {} +
   LC_ALL=C sed -i "" "s~*       @ConduitIO/conduit-core~ ~g" .github/CODEOWNERS
 else
-  find . -type f ! -name "setup.sh" -exec sed -i "s~github.com/conduitio/conduit-connector-connectorName~github.com/$MODULE_NAME~g" {} +
-  find . -type f ! -name "setup.sh" -exec sed -i "s~connectorName~$CONNECTOR_NAME~g" {} +
+  find . -type f ! -name "setup.sh" -exec sed -i "s~github.com/conduitio/conduit-connector-connectorname~github.com/$MODULE_NAME~g" {} +
+  find . -type f ! -name "setup.sh" -exec sed -i "s~connectorname~$CONNECTOR_NAME~g" {} +
   sed -i "s~*       @ConduitIO/conduit-core~ ~g" .github/CODEOWNERS
 fi
 

--- a/source.go
+++ b/source.go
@@ -1,4 +1,4 @@
-package connectorName
+package connectorname
 
 import (
 	"context"

--- a/source_test.go
+++ b/source_test.go
@@ -25,6 +25,5 @@ func TestTeardownSource_NoOpen(t *testing.T) {
 	err := con.Teardown(context.Background())
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
-
 	}
 }

--- a/source_test.go
+++ b/source_test.go
@@ -1,15 +1,15 @@
-package connectorName_test
+package connectorname_test
 
 import (
 	"context"
 	"strings"
 	"testing"
 
-	connectorName "github.com/conduitio/conduit-connector-connectorName"
+	connectorname "github.com/conduitio/conduit-connector-connectorname"
 )
 
 func TestConfigureSource_FailsWhenConfigEmpty(t *testing.T) {
-	con := connectorName.Source{}
+	con := connectorname.Source{}
 	err := con.Configure(context.Background(), make(map[string]string))
 	if err == nil {
 		t.Error("expected error for missing config params")
@@ -21,7 +21,7 @@ func TestConfigureSource_FailsWhenConfigEmpty(t *testing.T) {
 }
 
 func TestTeardownSource_NoOpen(t *testing.T) {
-	con := connectorName.NewSource()
+	con := connectorname.NewSource()
 	err := con.Teardown(context.Background())
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)

--- a/spec.go
+++ b/spec.go
@@ -1,4 +1,4 @@
-package connectorName
+package connectorname
 
 import (
 	sdk "github.com/conduitio/conduit-connector-sdk"
@@ -7,7 +7,7 @@ import (
 // Specification returns the connector's specification.
 func Specification() sdk.Specification {
 	return sdk.Specification{
-		Name:        "connectorName",
+		Name:        "connectorname",
 		Summary:     "<describe your connector>",
 		Description: "<describe your connector in detail>",
 		Version:     "v0.1.0",


### PR DESCRIPTION
Adds configuration files for golangci-lint and goreleaser.

It also renames `connectorName` to `connectorname` to make the linter happy.