### PR TITLE
Housekeeping: use ldflags to set version, goreleaser name template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,12 +11,13 @@ builds:
 checksum:
   name_template: checksums.txt
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 changelog:
   sort: asc
   use: github

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: build test test-integration
 
+VERSION=$(shell git describe --tags --dirty --always)
+
 build:
-	go build -o conduit-connector-connectorname cmd/connector/main.go
+	go build -ldflags "-X 'github.com/conduitio/conduit-connector-connectorname.version=${VERSION}'" -o conduit-connector-connectorname cmd/connector/main.go
 
 test:
-	go test $(GOTEST_FLAGS) -v -race ./...
+	go test $(GOTEST_FLAGS) -race ./...
 
 test-integration:
 	# run required docker containers, execute integration tests, stop containers after tests

--- a/spec.go
+++ b/spec.go
@@ -4,13 +4,17 @@ import (
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
+// version is set during the build process with ldflags (see Makefile).
+// Default version matches default from runtime/debug.
+var version = "(devel)"
+
 // Specification returns the connector's specification.
 func Specification() sdk.Specification {
 	return sdk.Specification{
 		Name:        "connectorname",
 		Summary:     "<describe your connector>",
 		Description: "<describe your connector in detail>",
-		Version:     "v0.1.0",
+		Version:     version,
 		Author:      "<your name>",
 	}
 }


### PR DESCRIPTION
### Description

Updates the template to use ldflags to set the connector version, also updates the goreleaser name template.