### PR TITLE
Fix module name

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,8 @@ fi
 MODULE_NAME=$1
 if ! [[ "$MODULE_NAME" =~ ^github.com\/.*\/conduit-connector-(.*)$ ]]
 then
-  echo "Module name ${MODULE_NAME} not in recommended format github.com/repository/conduit-connector-connectorname.\n"
+  echo "Module name ${MODULE_NAME} not in recommended format \"github.com/repository/conduit-connector-connectorname\"."
+  echo
   echo "Certain things (such as pull request templates) will not work correctly."
   while true; do
       read -n1 -p "Are you sure you want to continue? [y/n] " yn


### PR DESCRIPTION
### Description

Currently, when `setup.sh` is used, a double `github.com` will appear in module name. This PR fixes that.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio/conduit-connector-template/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.