### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # Define code owners (individuals or teams that are responsible for code in this repository)
 # More about code owners at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 *       @ConduitIO/conduit-core
+*       @conduitio-labs/conduit-core


### PR DESCRIPTION
### Description

Looks like every connector that's being generated using this template, could end up in the GitHub organization `conduitio-labs` which means will bring an incorrect `CODEOWNER`. 

This PR should accommodate for both. Once moved to either organization, the one that doesn't apply could be removed.

An alternative (which is the most likely situation) is to actually move this template to conduitio-labs and then the core team update to the right CODEOWNER.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio/conduit-connector-connectorname/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.