### PR TITLE
Add a debug build to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ VERSION=$(shell git describe --tags --dirty --always)
 build:
 	go build -ldflags "-X 'github.com/conduitio/conduit-connector-connectorname.version=${VERSION}'" -o conduit-connector-connectorname cmd/connector/main.go
 
+.PHONY: build-debug
+build-debug:
+	go build -gcflags=all="-N -l" -ldflags="-X 'github.com/conduitio/conduit-connector-connectorname.version=${VERSION}'" -o conduit-connector-connectorname cmd/connector/main.go
+
 .PHONY: test
 test:
 	go test $(GOTEST_FLAGS) -race ./...


### PR DESCRIPTION
### Description

Allows for step debugging a connector. More context in this discussion which provides instructions to step debug a connector 

https://github.com/ConduitIO/conduit/discussions/1724#discussioncomment-10768981

Fixes ConduitIO/conduit-site#176 

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio/conduit-connector-connectorname/pulls) for the same update/change.
- [x] I have written unit tests. (Not applicable, i think)
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.